### PR TITLE
feat!: make code null safe

### DIFF
--- a/lib/dedent.dart
+++ b/lib/dedent.dart
@@ -14,24 +14,27 @@ import 'package:quiver/iterables.dart';
 /// considered to have no common leading whitespace.
 /// Entirely blank lines are normalized to a newline character.
 String dedent(String text) {
-
   var _whitespaceOnlyRe = new RegExp(r"^[ \t]+$", multiLine: true);
   var _leadingWhitespaceRe =
       new RegExp(r"(^[ \t]*)(?:[^ \t\n])", multiLine: true);
 
-  // Look for the longest leading string of spaces and tabs common to
-  // all lines.
-  String margin;
   text = text.replaceAll(_whitespaceOnlyRe, '');
   var indents = _leadingWhitespaceRe.allMatches(text);
-  indents.forEach((_indent) {
+
+  if (indents.isEmpty) {
+    return text;
+  }
+
+  // Look for the longest leading string of spaces and tabs common to
+  // all lines.
+  String margin = text.substring(indents.first.start, indents.first.end - 1);
+
+  indents.skip(1).forEach((_indent) {
     String indent = text.substring(_indent.start, _indent.end - 1);
-    if (margin == null)
-      margin = indent;
 
     // Current line more deeply indented than previous winner:
     // no change (previous winner is still on top).
-    else if (indent.startsWith(margin)) {
+    if (indent.startsWith(margin)) {
     }
 
     // Current line consistent with and no deeper than previous winner:
@@ -68,5 +71,6 @@ String dedent(String text) {
         multiLine: true); // python r"(?m)^" illegal in js regex so leave it out
     text = text.replaceAll(r, '');
   }
+
   return text;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.3.0"
   flutter:
     dependency: transitive
     description: flutter
@@ -66,28 +66,35 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   quiver:
     dependency: "direct main"
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,56 +106,49 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
-  flutter: ">=1.17.0 <2.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
+  flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=1.17.0 <2.0.0"
 
 dependencies:
-  quiver: ^2.1.3
+  quiver: ^3.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Closes #1.

Makes the code null safe. To test, update `environment.sdk` within pubspec.yaml to `">=2.12.0 <3.0.0"` and verify all tests work by running `flutter test`.

**Important.** I did not update CHANGELOG.md, nor did I update  `version` or `envionment.sdk` within pubspec.yaml, since I figure @abulka may want to do that and publish the changes to pub themselves. (Also, I'm very new to the Dart ecosystem, so I am not 100% if this should be a major version change. I imagine it should be since `environment.sdk` would be changed, but I am not certain. If @abulka would like me to figure all that out, I can do more research.)

